### PR TITLE
fix: Updates for contemporary Python.

### DIFF
--- a/epson/constant.py
+++ b/epson/constant.py
@@ -40,14 +40,14 @@ def clamp(minvalue, value, maxvalue):
 def byte(*sequential):
     return bytearray(sequential)
 
-def RunLengthEncode(line = None, bytes_per_pixel = 3):
+def run_length_encode(line: bytes, bytes_per_pixel = 3):
     out = b""
-    repcnt = 0
 
     pixel = 0
     while pixel < len(line):
         tpix = line[pixel:pixel+bytes_per_pixel]
         next_pixel = pixel + bytes_per_pixel
+        repeat = 1
         if next_pixel < len(line):
             npix = line[next_pixel:next_pixel+bytes_per_pixel]
             repeat = 1
@@ -57,9 +57,7 @@ def RunLengthEncode(line = None, bytes_per_pixel = 3):
                 next_pixel += bytes_per_pixel
                 repeat += 1
                 npix = line[next_pixel:next_pixel+bytes_per_pixel]
-                pass
-        else:
-            repeat = 1
+
         if repeat == 1:
             # Unique data
             unique = 2
@@ -69,7 +67,6 @@ def RunLengthEncode(line = None, bytes_per_pixel = 3):
                 next_pixel += bytes_per_pixel
                 unique += 1
                 npix = line[next_pixel:next_pixel+bytes_per_pixel]
-                pass
             out += byte(unique - 1)
             out += line[pixel:next_pixel]
         else:

--- a/epson/escpr.py
+++ b/epson/escpr.py
@@ -26,9 +26,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
-import sys
-import time
 import math
 import struct
 import epson
@@ -47,7 +44,6 @@ class Interface(epson.escp.Interface):
     def __init__(self, io = None):
         """ Initialize class """
         super(Interface, self).__init__(io = io)
-        pass
 
     """ ESC/P Raster Mode """
     def _raster_enter(self, jpeg = False):
@@ -56,7 +52,6 @@ class Interface(epson.escp.Interface):
         else:
             self._send(self.ESCPRMode)
 
-        pass
 
     """ Raster Mode command wrappers """
     def _raster_cmd(self, cmd, code, data = None):
@@ -79,7 +74,6 @@ class Interface(epson.escp.Interface):
                  palette
                )
         self._raster_cmd(b"q", b"setq", data)
-        pass
 
     def _raster_check(self):
         # Only needed on 'version 3' or higher printers?
@@ -123,12 +117,10 @@ class Interface(epson.escp.Interface):
     def _jpeg_auto_photo_fix(self, cm = CM.COLOR, act = ACT.NOTHING, sharpness = 0, rde = RDE.NOTHING):
         data = byte(cm) + byte(act) + byte(clamp(-50, sharpness, 50)) + byte(rde)
         self._raster_cmd(b"a", b"seta", data)
-        pass
 
     def _jpeg_copies(self, copies = 1):
         data = byte(clamp(1, copies, 255))
         self._raster_cmd(b"c", b"setc", data)
-        pass
 
     def _jpeg_job(self):
         # TODO: Add JPEG page size support
@@ -157,16 +149,13 @@ class Interface(epson.escp.Interface):
         data += byte(clamp(114, cddim_od, 120))
         date += byte(pd)
 
-        self,_raster_cmd(b"j", b"sets", data)
-        pass
+        self._raster_cmd(b"j", b"sets", data)
 
     def _raster_start_page(self):
         self._raster_cmd(b"p", b"sttp")
-        pass
 
     def _raster_printnum2(self, pageno = 1):
         self._raster_cmd(b"p",b"setn",byte(pageno))
-        pass
 
     def _send_jpeg(self, chunk):
         while len(chunk) > 0:
@@ -175,12 +164,10 @@ class Interface(epson.escp.Interface):
                 size = 0xffff
             self._raster_cmd(b"d",b"jsnd", struct.pack(">H", size) + chunk[0:size])
             chunk = chunk[size:]
-            pass
-        pass
 
     def _send_line(self, line = None, offset = (0, 0), compress = False):
         if compress:
-            line = epson.escpr.RunLengthEncode(line, 3)
+            line = epson.escpr.run_length_encode(line, 3)
             cmode = 1
         else:
             cmode = 0
@@ -188,11 +175,9 @@ class Interface(epson.escp.Interface):
         data = struct.pack(">HHBH",  offset[0], offset[1], cmode, len(line))
 
         self._raster_cmd(b"d",b"dsnd", data + line)
-        pass
 
     def _raster_endpage(self, pages_remaining = 0):
         self._raster_cmd(b"p", b"endp", byte(pages_remaining))
-        pass
 
     def _raster_endjob(self):
         self._raster_cmd(b"j", b"endj")
@@ -299,7 +284,6 @@ class Job(Interface):
                              pd = self.pd,
                              cddim_id = self.cddim_id,
                              cddim_od = self.cddim_od)
-            pass
 
         return size
 
@@ -335,10 +319,8 @@ class Job(Interface):
             if rpage > 99:
                 rpage = 99
             self._raster_endpage(pages_remaining = rpage)
-            pass
 
         self._end()
-        pass
 
 
 #  vim: set shiftwidth=4 expandtab: # 

--- a/epson/raster.py
+++ b/epson/raster.py
@@ -28,6 +28,7 @@ from __future__ import division
 from __future__ import print_function
 
 import struct
+from typing import Optional
 from epson.constant import *
 
 class Image(object):
@@ -35,21 +36,19 @@ class Image(object):
     def __init__(self, size = (0, 0)):
         self.size = size[:]
 
-    def bitline(self, y = 0, ci = CI.BLACK, bpp = 1):
+    def bitline(self, y = 0, ci = CI.BLACK, bpp = 1) -> Optional[bytes]:
         """ Retrieve a bitmap of a line in a single color """
-        return ""
+        return b""
 
     def line(self, y = 0):
-        """ Retieve a RGB 24-bit line from the bitmap """
+        """ Retrieve a RGB 24-bit line from the bitmap """
         return ""
 
 class TestImage(Image):
     """ Test Image """
 
-    def bitline(self, y = 0, ci = CI.BLACK, bpp = 1):
+    def bitline(self, y = 0, ci = CI.BLACK, bpp = 1) -> Optional[bytes]:
         """ Retrieve a bitmap of a line in a single color """
-
-        width = self.size[0]
 
         # Every 60 lines, change color
         line_color = int(y / 60) % 15
@@ -57,8 +56,10 @@ class TestImage(Image):
         if (line_color & (1 << ci)) == 0:
             return None
 
+        width = self.size[0]
+
         # Return a full raster line
-        return chr(0xff) * int((width + 7) / 8) * bpp
+        return b"\xff" * int((width + 7) / 8) * bpp
 
     def line(self, y = 0):
         """ Retrieve a RGB 24-bit line from the bitmap """


### PR DESCRIPTION
- Fixes a few `str` that should've been `bytes`, and `float`s that should've been `int`.
- Fixes a `,` that should've been a `.`.
- Removes some dead code.
- Reformats some code to be more consistent, and follow contemporary conventions.

Tested with Python 3.13.1.